### PR TITLE
decoder example changes

### DIFF
--- a/examples/cmdline_decoder/mqoi_decoder.c
+++ b/examples/cmdline_decoder/mqoi_decoder.c
@@ -11,7 +11,7 @@
 
 uint64_t micros(){
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     uint64_t us = (uint64_t)ts.tv_sec * 1000000ull + (uint64_t)ts.tv_nsec / 1000ull;
     return us;
 }
@@ -89,14 +89,14 @@ int main(int argc, const char * argv[]) {
 
     char * img_data = malloc(img_size);
     if (img_data == NULL) {
-      printf("couldn't allocate input buffer!\n");
-      return -1;
+        printf("couldn't allocate input buffer!\n");
+        return -1;
     }
 
     mqoi_rgba_t * opt_data = malloc(opt_size);
     if (opt_data == NULL) {
-      printf("couldn't allocate output buffer!\n");
-      return -1;
+        printf("couldn't allocate output buffer!\n");
+        return -1;
     }
 
     memcpy(&img_data[img_head], &img_desc.magic, MQOI_HEADER_SIZE);

--- a/examples/cmdline_decoder/mqoi_decoder.c
+++ b/examples/cmdline_decoder/mqoi_decoder.c
@@ -88,21 +88,20 @@ int main(int argc, const char * argv[]) {
         opt_size = img_w * img_h * sizeof(mqoi_rgba_t);
 
     char * img_data = malloc(img_size);
+    if (img_data == NULL) {
+      printf("couldn't allocate input buffer!\n");
+      return -1;
+    }
+
     mqoi_rgba_t * opt_data = malloc(opt_size);
+    if (opt_data == NULL) {
+      printf("couldn't allocate output buffer!\n");
+      return -1;
+    }
 
     memcpy(&img_data[img_head], &img_desc.magic, MQOI_HEADER_SIZE);
 
     img_head += MQOI_HEADER_SIZE;
-
-    if (img_data == NULL) {
-        printf("couldn't allocate input buffer!\n");
-        return -1;
-    }
-
-    if (opt_data == NULL) {
-        printf("couldn't allocate output buffer!\n");
-        return -1;
-    }
 
     if (fread(&img_data[img_head], 1, img_size - img_head, img_f) < img_size - img_head) {
         printf("couldn't read all compressed image data!\n");

--- a/examples/cmdline_decoder/mqoi_decoder.c
+++ b/examples/cmdline_decoder/mqoi_decoder.c
@@ -49,9 +49,6 @@ int main(int argc, const char * argv[]) {
         case MQOI_DESC_INVALID_MAGIC: printf("image had an invalid magic value!\n"); return -1;
         case MQOI_DESC_INVALID_CHANNELS: printf("image had an invalid channel number!\n"); return -1;
         case MQOI_DESC_INVALID_COLORSPACE: printf("image had an invalid colorspace!\n"); return -1;
-        case MQOI_DESC_INVALID_SIZE: 
-            printf("image of size %ux%u has more than 400 million pixels!\n", img_w, img_h); 
-            return -1;
         default: break;
     }
 


### PR DESCRIPTION
This pull request makes 3 changes to the mqoi_decoder example, beginning at the top of the file these are:

- use CLOCK_MONOTONIC instead of CLOCK_MONOTONIC_RAW for better compatibility
  - this was changed because the _RAW variant is not available with MinGW
  - now also works with older linux versions <v2.6.28 (probaly irelevant)
- remove usage of undefined MQOI_DESC_INVALID_SIZE
  - this was probably left over from a previous version
- move null ptr checks directly under malloc
  - img_data was used with memcpy before checking (potential for undefined behavior)
  - checking for null right away also helps prevent similar issues in future