### PR TITLE
fix alignment of fields within mqoi_desc_t

### DIFF
--- a/src/mini_qoi.c
+++ b/src/mini_qoi.c
@@ -44,6 +44,7 @@ Initializes an mQOI image descriptor object.
 */
 void mqoi_desc_init(mqoi_desc_t * desc) {
     memset(desc, 0, sizeof(mqoi_desc_t));
+    desc->head = 3;
 }
 
 /* 
@@ -90,7 +91,7 @@ uint8_t mqoi_desc_verify(mqoi_desc_t * desc, uint32_t * w, uint32_t * h) {
 Returns true when the mQOI image descriptor object is completely populated.
 */
 MQOI_INLINE bool mqoi_desc_done(const mqoi_desc_t * desc) {
-    return desc->head >= sizeof(mqoi_desc_t) - 1;
+    return desc->head >= sizeof(mqoi_desc_t) - 4;
 }
 
 // ==== mqoi_dec_t ====

--- a/src/mini_qoi.h
+++ b/src/mini_qoi.h
@@ -61,7 +61,7 @@ typedef union {
 } mqoi_rgba_t;
 
 typedef struct {
-    uint8_t head;
+    uint32_t head;
 
     uint8_t magic[4];
     uint8_t width[4]; // big-endian width


### PR DESCRIPTION
Attempting to use the minimal code example on an RP2040 fails (the board crashes) while attempting to run mqoi_desc_verify.
I narrowed the crash down to the line https://github.com/shraiwi/mini-qoi/blob/master/src/mini_qoi.c#L34, which casts a potentially unaligned uint8_t* to a uint32_t*, which is undefined behavior. Padding the struct so the width/height fields are 4-byte aligned fixes the issue.